### PR TITLE
add idempotency key & BRI api key on charge direct debit

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,11 +15,13 @@ import (
 )
 
 type Client struct {
-	BaseUrl      string
-	ClientId     string
-	ClientSecret string
-	LogLevel     int
-	Logger       *log.Logger
+	BaseUrl            string
+	DirectDebitBaseURL string
+	ClientId           string
+	ClientSecret       string
+	APIKey             string
+	LogLevel           int
+	Logger             *log.Logger
 }
 
 // NewClient : this function will always be called when the library is in use

--- a/core.go
+++ b/core.go
@@ -30,6 +30,16 @@ func (gateway *CoreGateway) Call(method, path string, header map[string]string, 
 	return gateway.Client.Call(method, path, header, body, v)
 }
 
+// CallDirectDebit will call direct debit api
+func (gateway *CoreGateway) CallDirectDebit(method, path string, header map[string]string, body io.Reader, v interface{}) error {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	path = gateway.Client.DirectDebitBaseURL + path
+	return gateway.Client.Call(method, path, header, body, v)
+}
+
 func (gateway *CoreGateway) GetToken() (res TokenResponse, err error) {
 	data := url.Values{}
 	data.Set("client_id", gateway.Client.ClientId)

--- a/core_test.go
+++ b/core_test.go
@@ -1,8 +1,6 @@
 package bri
 
 import (
-	"crypto/sha1"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"strconv"
@@ -37,15 +35,6 @@ type credentials struct {
 	CardPan            string
 	PhoneNumber        string
 	Email              string
-}
-
-// generateSha1Timestamp will generate sha1 hash from UnixNano timestamp
-func generateSha1Timestamp(salt string) string {
-	key := fmt.Sprintf("%s-%d", salt, time.Now().UnixNano())
-
-	h := sha1.New()
-	h.Write([]byte(key))
-	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func TestBriSanguTestSuite(t *testing.T) {

--- a/core_test.go
+++ b/core_test.go
@@ -1,6 +1,8 @@
 package bri
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"strconv"
@@ -16,12 +18,34 @@ import (
 type BriSanguTestSuite struct {
 	suite.Suite
 	client Client
+
+	// property for direct debit
+	cardPan               string
+	phoneNumber           string
+	email                 string
+	registrationCardToken string
+	cardToken             string
+	chargeToken           string
 }
 
 type credentials struct {
-	BaseUrl      string
-	ClientId     string
-	ClientSecret string
+	BaseUrl            string
+	DirectDebitBaseURL string
+	ClientId           string
+	ClientSecret       string
+	APIKey             string
+	CardPan            string
+	PhoneNumber        string
+	Email              string
+}
+
+// generateSha1Timestamp will generate sha1 hash from UnixNano timestamp
+func generateSha1Timestamp(salt string) string {
+	key := fmt.Sprintf("%s-%d", salt, time.Now().UnixNano())
+
+	h := sha1.New()
+	h.Write([]byte(key))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func TestBriSanguTestSuite(t *testing.T) {
@@ -43,8 +67,13 @@ func (bri *BriSanguTestSuite) SetupTest() {
 
 	bri.client = NewClient()
 	bri.client.BaseUrl = cred.BaseUrl
+	bri.client.DirectDebitBaseURL = cred.DirectDebitBaseURL
 	bri.client.ClientId = cred.ClientId
 	bri.client.ClientSecret = cred.ClientSecret
+	bri.client.APIKey = cred.APIKey
+	bri.cardPan = cred.CardPan
+	bri.phoneNumber = cred.PhoneNumber
+	bri.email = cred.Email
 }
 
 func (bri *BriSanguTestSuite) TestGetTokenSuccess() {

--- a/credential_test.toml.sample
+++ b/credential_test.toml.sample
@@ -1,5 +1,10 @@
 BaseUrl = "https://bri-host"
-DirectDebitBaseURL = "https://bri-direct-debit-host"
+DirectDebitBaseURL = "https://bri-direct-debit-host"  # remove /sandbox prefix, added later in unit test
 ClientId = "your-client-id"
 ClientSecret = "your-client-secret"
 APIKey = "your-bri-api-key"
+
+# for direct debit
+CardPan = "your-card-pan"
+PhoneNumber = "your-phonenumber"
+Email = "your-email"

--- a/credential_test.toml.sample
+++ b/credential_test.toml.sample
@@ -1,3 +1,5 @@
 BaseUrl = "https://bri-host"
+DirectDebitBaseURL = "https://bri-direct-debit-host"
 ClientId = "your-client-id"
 ClientSecret = "your-client-secret"
+APIKey = "your-bri-api-key"

--- a/direct_debit.go
+++ b/direct_debit.go
@@ -15,7 +15,7 @@ const (
 
 // CreateCardTokenOTP verifies that the information provided by the customers matches the bank data.
 // This API will alse send OTP code confirmation to user if user phonenumber is valid.
-func (g *CoreGateway) CreateCardTokenOTP(token string, req CardTokenOTPRequest) (res CardTokenOTPResponse, err error) {
+func (g *CoreGateway) CreateCardTokenOTP(token, briAPIKey string, req CardTokenOTPRequest) (res CardTokenOTPResponse, err error) {
 	req.Body.OtpBriStatus = "YES"
 
 	token = "Bearer " + token
@@ -25,10 +25,11 @@ func (g *CoreGateway) CreateCardTokenOTP(token string, req CardTokenOTPRequest) 
 	signature := generateSignature(urlCreateCardTokenOTP, method, token, timestamp, string(body), g.Client.ClientSecret)
 
 	headers := map[string]string{
-		"Authorization": token,
-		"BRI-Timestamp": timestamp,
-		"BRI-Signature": signature,
-		"Content-Type":  "application/json",
+		"Authorization":   token,
+		"BRI-Timestamp":   timestamp,
+		"X-BRI-Signature": signature,
+		"Content-Type":    "application/json",
+		"X-BRI-Api-Key":   briAPIKey,
 	}
 
 	err = g.Call(method, urlCreateCardTokenOTP, headers, strings.NewReader(string(body)), &res)
@@ -36,7 +37,7 @@ func (g *CoreGateway) CreateCardTokenOTP(token string, req CardTokenOTPRequest) 
 }
 
 // CreateCardTokenOTPVerify is used to verify OTP from create card token OTP url.
-func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVerifyRequest) (res CardTokenOTPVerifyResponse, err error) {
+func (g *CoreGateway) CreateCardTokenOTPVerify(token, briAPIKey string, req CardTokenOTPVerifyRequest) (res CardTokenOTPVerifyResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPatch
 	body, err := json.Marshal(req)
@@ -44,10 +45,11 @@ func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVer
 	signature := generateSignature(urlCreateCardTokenOTPVerify, method, token, timestamp, string(body), g.Client.ClientSecret)
 
 	headers := map[string]string{
-		"Authorization": token,
-		"BRI-Timestamp": timestamp,
-		"BRI-Signature": signature,
-		"Content-Type":  "application/json",
+		"Authorization":   token,
+		"BRI-Timestamp":   timestamp,
+		"X-BRI-Signature": signature,
+		"Content-Type":    "application/json",
+		"X-BRI-Api-Key":   briAPIKey,
 	}
 
 	err = g.Call(method, urlCreateCardTokenOTPVerify, headers, strings.NewReader(string(body)), &res)
@@ -56,7 +58,7 @@ func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVer
 
 // CreatePaymentChargeOTP is used for payment of direct link transactions based on card number via card_token acquired from binding process (create a card token).
 // This API will alse send OTP code confirmation to user if user phonenumber is valid.
-func (g *CoreGateway) CreatePaymentChargeOTP(token, idempotencyKey string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
+func (g *CoreGateway) CreatePaymentChargeOTP(token, briAPIKey, idempotencyKey string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPost
 	body, err := json.Marshal(req)
@@ -66,9 +68,10 @@ func (g *CoreGateway) CreatePaymentChargeOTP(token, idempotencyKey string, req P
 	headers := map[string]string{
 		"Authorization":   token,
 		"BRI-Timestamp":   timestamp,
-		"BRI-Signature":   signature,
+		"X-BRI-Signature": signature,
 		"Content-Type":    "application/json",
 		"Idempotency-Key": idempotencyKey,
+		"X-BRI-Api-Key":   briAPIKey,
 	}
 
 	err = g.Call(method, urlCreatePaymentChargeOTP, headers, strings.NewReader(string(body)), &res)
@@ -76,7 +79,7 @@ func (g *CoreGateway) CreatePaymentChargeOTP(token, idempotencyKey string, req P
 }
 
 // CreatePaymentChargeOTPVerify is used to verify OTP from create payment charge OTP url.
-func (g *CoreGateway) CreatePaymentChargeOTPVerify(token string, req PaymentChargeOTPVerifyRequest) (res PaymentChargeResponse, err error) {
+func (g *CoreGateway) CreatePaymentChargeOTPVerify(token, briAPIKey string, req PaymentChargeOTPVerifyRequest) (res PaymentChargeResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPost
 	body, err := json.Marshal(req)
@@ -84,10 +87,11 @@ func (g *CoreGateway) CreatePaymentChargeOTPVerify(token string, req PaymentChar
 	signature := generateSignature(urlCreatePaymentChargeOTPVerify, method, token, timestamp, string(body), g.Client.ClientSecret)
 
 	headers := map[string]string{
-		"Authorization": token,
-		"BRI-Timestamp": timestamp,
-		"BRI-Signature": signature,
-		"Content-Type":  "application/json",
+		"Authorization":   token,
+		"BRI-Timestamp":   timestamp,
+		"X-BRI-Signature": signature,
+		"Content-Type":    "application/json",
+		"X-BRI-Api-Key":   briAPIKey,
 	}
 
 	err = g.Call(method, urlCreatePaymentChargeOTPVerify, headers, strings.NewReader(string(body)), &res)

--- a/direct_debit.go
+++ b/direct_debit.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const (
+var (
 	urlCreateCardTokenOTP           = "/v1/directdebit/tokens"         // POST
 	urlCreateCardTokenOTPVerify     = "/v1/directdebit/tokens"         // PATCH
 	urlDeleteCardToken              = "/v1/directdebit/tokens"         // DELETE

--- a/direct_debit.go
+++ b/direct_debit.go
@@ -9,6 +9,7 @@ import (
 const (
 	urlCreateCardTokenOTP           = "/v1/directdebit/tokens"         // POST
 	urlCreateCardTokenOTPVerify     = "/v1/directdebit/tokens"         // PATCH
+	urlDeleteCardToken              = "/v1/directdebit/tokens"         // DELETE
 	urlCreatePaymentChargeOTP       = "/v1/directdebit/charges"        // POST
 	urlCreatePaymentChargeOTPVerify = "/v1/directdebit/charges/verify" // POST
 )
@@ -53,6 +54,26 @@ func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVer
 	}
 
 	err = g.CallDirectDebit(method, urlCreateCardTokenOTPVerify, headers, strings.NewReader(string(body)), &res)
+	return
+}
+
+// DeleteCardToken is used to unbind user's direct debit card token
+func (g *CoreGateway) DeleteCardToken(token string, req DeleteCardTokenRequest) (res DeleteCardTokenResponse, err error) {
+	token = "Bearer " + token
+	method := http.MethodDelete
+	body, err := json.Marshal(req)
+	timestamp := getTimestamp(BRI_TIME_FORMAT)
+	signature := generateSignature(urlDeleteCardToken, method, token, timestamp, string(body), g.Client.ClientSecret)
+
+	headers := map[string]string{
+		"Authorization":   token,
+		"BRI-Timestamp":   timestamp,
+		"X-BRI-Signature": signature,
+		"Content-Type":    "application/json",
+		"X-BRI-Api-Key":   g.Client.APIKey,
+	}
+
+	err = g.CallDirectDebit(method, urlDeleteCardToken, headers, strings.NewReader(string(body)), &res)
 	return
 }
 

--- a/direct_debit.go
+++ b/direct_debit.go
@@ -15,7 +15,7 @@ const (
 
 // CreateCardTokenOTP verifies that the information provided by the customers matches the bank data.
 // This API will alse send OTP code confirmation to user if user phonenumber is valid.
-func (g *CoreGateway) CreateCardTokenOTP(token, briAPIKey string, req CardTokenOTPRequest) (res CardTokenOTPResponse, err error) {
+func (g *CoreGateway) CreateCardTokenOTP(token string, req CardTokenOTPRequest) (res CardTokenOTPResponse, err error) {
 	req.Body.OtpBriStatus = "YES"
 
 	token = "Bearer " + token
@@ -29,15 +29,15 @@ func (g *CoreGateway) CreateCardTokenOTP(token, briAPIKey string, req CardTokenO
 		"BRI-Timestamp":   timestamp,
 		"X-BRI-Signature": signature,
 		"Content-Type":    "application/json",
-		"X-BRI-Api-Key":   briAPIKey,
+		"X-BRI-Api-Key":   g.Client.APIKey,
 	}
 
-	err = g.Call(method, urlCreateCardTokenOTP, headers, strings.NewReader(string(body)), &res)
+	err = g.CallDirectDebit(method, urlCreateCardTokenOTP, headers, strings.NewReader(string(body)), &res)
 	return
 }
 
 // CreateCardTokenOTPVerify is used to verify OTP from create card token OTP url.
-func (g *CoreGateway) CreateCardTokenOTPVerify(token, briAPIKey string, req CardTokenOTPVerifyRequest) (res CardTokenOTPVerifyResponse, err error) {
+func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVerifyRequest) (res CardTokenOTPVerifyResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPatch
 	body, err := json.Marshal(req)
@@ -49,16 +49,16 @@ func (g *CoreGateway) CreateCardTokenOTPVerify(token, briAPIKey string, req Card
 		"BRI-Timestamp":   timestamp,
 		"X-BRI-Signature": signature,
 		"Content-Type":    "application/json",
-		"X-BRI-Api-Key":   briAPIKey,
+		"X-BRI-Api-Key":   g.Client.APIKey,
 	}
 
-	err = g.Call(method, urlCreateCardTokenOTPVerify, headers, strings.NewReader(string(body)), &res)
+	err = g.CallDirectDebit(method, urlCreateCardTokenOTPVerify, headers, strings.NewReader(string(body)), &res)
 	return
 }
 
 // CreatePaymentChargeOTP is used for payment of direct link transactions based on card number via card_token acquired from binding process (create a card token).
 // This API will alse send OTP code confirmation to user if user phonenumber is valid.
-func (g *CoreGateway) CreatePaymentChargeOTP(token, briAPIKey, idempotencyKey string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
+func (g *CoreGateway) CreatePaymentChargeOTP(token, idempotencyKey string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPost
 	body, err := json.Marshal(req)
@@ -71,15 +71,15 @@ func (g *CoreGateway) CreatePaymentChargeOTP(token, briAPIKey, idempotencyKey st
 		"X-BRI-Signature": signature,
 		"Content-Type":    "application/json",
 		"Idempotency-Key": idempotencyKey,
-		"X-BRI-Api-Key":   briAPIKey,
+		"X-BRI-Api-Key":   g.Client.APIKey,
 	}
 
-	err = g.Call(method, urlCreatePaymentChargeOTP, headers, strings.NewReader(string(body)), &res)
+	err = g.CallDirectDebit(method, urlCreatePaymentChargeOTP, headers, strings.NewReader(string(body)), &res)
 	return
 }
 
 // CreatePaymentChargeOTPVerify is used to verify OTP from create payment charge OTP url.
-func (g *CoreGateway) CreatePaymentChargeOTPVerify(token, briAPIKey string, req PaymentChargeOTPVerifyRequest) (res PaymentChargeResponse, err error) {
+func (g *CoreGateway) CreatePaymentChargeOTPVerify(token string, req PaymentChargeOTPVerifyRequest) (res PaymentChargeResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPost
 	body, err := json.Marshal(req)
@@ -91,9 +91,9 @@ func (g *CoreGateway) CreatePaymentChargeOTPVerify(token, briAPIKey string, req 
 		"BRI-Timestamp":   timestamp,
 		"X-BRI-Signature": signature,
 		"Content-Type":    "application/json",
-		"X-BRI-Api-Key":   briAPIKey,
+		"X-BRI-Api-Key":   g.Client.APIKey,
 	}
 
-	err = g.Call(method, urlCreatePaymentChargeOTPVerify, headers, strings.NewReader(string(body)), &res)
+	err = g.CallDirectDebit(method, urlCreatePaymentChargeOTPVerify, headers, strings.NewReader(string(body)), &res)
 	return
 }

--- a/direct_debit.go
+++ b/direct_debit.go
@@ -56,7 +56,7 @@ func (g *CoreGateway) CreateCardTokenOTPVerify(token string, req CardTokenOTPVer
 
 // CreatePaymentChargeOTP is used for payment of direct link transactions based on card number via card_token acquired from binding process (create a card token).
 // This API will alse send OTP code confirmation to user if user phonenumber is valid.
-func (g *CoreGateway) CreatePaymentChargeOTP(token string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
+func (g *CoreGateway) CreatePaymentChargeOTP(token, idempotencyKey string, req PaymentChargeOTPRequest) (res PaymentChargeResponse, err error) {
 	token = "Bearer " + token
 	method := http.MethodPost
 	body, err := json.Marshal(req)
@@ -64,10 +64,11 @@ func (g *CoreGateway) CreatePaymentChargeOTP(token string, req PaymentChargeOTPR
 	signature := generateSignature(urlCreatePaymentChargeOTP, method, token, timestamp, string(body), g.Client.ClientSecret)
 
 	headers := map[string]string{
-		"Authorization": token,
-		"BRI-Timestamp": timestamp,
-		"BRI-Signature": signature,
-		"Content-Type":  "application/json",
+		"Authorization":   token,
+		"BRI-Timestamp":   timestamp,
+		"BRI-Signature":   signature,
+		"Content-Type":    "application/json",
+		"Idempotency-Key": idempotencyKey,
 	}
 
 	err = g.Call(method, urlCreatePaymentChargeOTP, headers, strings.NewReader(string(body)), &res)

--- a/direct_debit_test.go
+++ b/direct_debit_test.go
@@ -1,12 +1,30 @@
 package bri
 
 import (
+	"crypto/sha1"
 	"fmt"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// generateSha1Timestamp will generate sha1 hash from UnixNano timestamp
+func generateSha1Timestamp(salt string) string {
+	key := fmt.Sprintf("%s-%d", salt, time.Now().UnixNano())
+
+	h := sha1.New()
+	h.Write([]byte(key))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
 func (bri *BriSanguTestSuite) TestDirectDebit_01_CreateCardToken() {
+	// modify url for unit test
+	urlCreateCardTokenOTP = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTP)
+	urlCreateCardTokenOTPVerify = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTPVerify)
+	urlCreatePaymentChargeOTP = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTP)
+	urlCreatePaymentChargeOTPVerify = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTPVerify)
+	urlDeleteCardToken = fmt.Sprintf("/sandbox%s", urlDeleteCardToken)
+
 	coreGateway := CoreGateway{
 		Client: bri.client,
 	}
@@ -22,8 +40,6 @@ func (bri *BriSanguTestSuite) TestDirectDebit_01_CreateCardToken() {
 	}
 
 	token := tokenResp.AccessToken
-	urlCreateCardTokenOTP = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTP)
-
 	resp, err := coreGateway.CreateCardTokenOTP(token, req)
 
 	assert.Equal(bri.T(), "PENDING_USER_VERIFICATION", resp.Body.Status)
@@ -46,8 +62,6 @@ func (bri *BriSanguTestSuite) TestDirectDebit_02_VerifyCreateCardToken() {
 	}
 
 	token := tokenResp.AccessToken
-	urlCreateCardTokenOTPVerify = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTPVerify)
-
 	resp, err := coreGateway.CreateCardTokenOTPVerify(token, req)
 
 	assert.Equal(bri.T(), "0000", resp.Body.Status)
@@ -77,8 +91,6 @@ func (bri *BriSanguTestSuite) TestDirectDebit_03_ChargePaymentNoOTP() {
 	}
 
 	token := tokenResp.AccessToken
-	urlCreatePaymentChargeOTP = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTP)
-
 	resp, err := coreGateway.CreatePaymentChargeOTP(token, idempotencyKey, req)
 
 	assert.Equal(bri.T(), "0000", resp.Body.Status)
@@ -130,8 +142,6 @@ func (bri *BriSanguTestSuite) TestDirectDebit_05_VerifyChargePaymentOTP() {
 	}
 
 	token := tokenResp.AccessToken
-	urlCreatePaymentChargeOTPVerify = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTPVerify)
-
 	resp, err := coreGateway.CreatePaymentChargeOTPVerify(token, req)
 
 	assert.Equal(bri.T(), "0000", resp.Body.Status)
@@ -152,7 +162,6 @@ func (bri *BriSanguTestSuite) TestDirectDebit_06_DeleteCardToken() {
 	}
 
 	token := tokenResp.AccessToken
-	urlDeleteCardToken = fmt.Sprintf("/sandbox%s", urlDeleteCardToken)
 	resp, err := coreGateway.DeleteCardToken(token, req)
 
 	assert.Equal(bri.T(), "0000", resp.Body.Status)

--- a/direct_debit_test.go
+++ b/direct_debit_test.go
@@ -1,0 +1,160 @@
+package bri
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (bri *BriSanguTestSuite) TestDirectDebit_01_CreateCardToken() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	req := CardTokenOTPRequest{
+		Body: CardTokenOTPRequestData{
+			CardPan:      bri.cardPan,
+			PhoneNumber:  bri.phoneNumber,
+			Email:        bri.email,
+			OtpBriStatus: "YES",
+		},
+	}
+
+	token := tokenResp.AccessToken
+	urlCreateCardTokenOTP = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTP)
+
+	resp, err := coreGateway.CreateCardTokenOTP(token, req)
+
+	assert.Equal(bri.T(), "PENDING_USER_VERIFICATION", resp.Body.Status)
+	assert.Equal(bri.T(), nil, err)
+
+	bri.registrationCardToken = resp.Body.Token
+}
+
+func (bri *BriSanguTestSuite) TestDirectDebit_02_VerifyCreateCardToken() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	req := CardTokenOTPVerifyRequest{
+		Body: CardTokenOTPVerifyRequestData{
+			RegistrationToken: bri.registrationCardToken,
+			Passcode:          "999999", // default dev otp code
+		},
+	}
+
+	token := tokenResp.AccessToken
+	urlCreateCardTokenOTPVerify = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTPVerify)
+
+	resp, err := coreGateway.CreateCardTokenOTPVerify(token, req)
+
+	assert.Equal(bri.T(), "0000", resp.Body.Status)
+	assert.Equal(bri.T(), nil, err)
+
+	bri.cardToken = resp.Body.CardToken
+}
+
+func (bri *BriSanguTestSuite) TestDirectDebit_03_ChargePaymentNoOTP() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	idempotencyKey := generateSha1Timestamp("03_ChargePaymentOTP")
+	req := PaymentChargeOTPRequest{
+		Body: PaymentChargeOTPRequestData{
+			CardToken:    bri.cardToken,
+			Amount:       "89000.00",
+			Currency:     "IDR",
+			Remarks:      "testing remarks from unit test",
+			OtpBriStatus: "NO",
+			Metadata: map[string]interface{}{
+				"": nil,
+			},
+		},
+	}
+
+	token := tokenResp.AccessToken
+	urlCreatePaymentChargeOTP = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTP)
+
+	resp, err := coreGateway.CreatePaymentChargeOTP(token, idempotencyKey, req)
+
+	assert.Equal(bri.T(), "0000", resp.Body.Status)
+	assert.Equal(bri.T(), "SUCCESS", resp.Body.PaymentStatus)
+	assert.Equal(bri.T(), nil, err)
+}
+
+func (bri *BriSanguTestSuite) TestDirectDebit_04_ChargePaymentOTP() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	idempotencyKey := generateSha1Timestamp("04_ChargePaymentOTP")
+	req := PaymentChargeOTPRequest{
+		Body: PaymentChargeOTPRequestData{
+			CardToken:    bri.cardToken,
+			Amount:       "63000.00",
+			Currency:     "IDR",
+			Remarks:      "testing remarks from unit test again",
+			OtpBriStatus: "YES",
+			Metadata: map[string]interface{}{
+				"": nil,
+			},
+		},
+	}
+
+	token := tokenResp.AccessToken
+	resp, err := coreGateway.CreatePaymentChargeOTP(token, idempotencyKey, req)
+
+	assert.Equal(bri.T(), "PENDING_USER_VERIFICATION", resp.Body.Status)
+	assert.Equal(bri.T(), nil, err)
+
+	bri.chargeToken = resp.Body.ChargeToken
+}
+
+func (bri *BriSanguTestSuite) TestDirectDebit_05_VerifyChargePaymentOTP() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	req := PaymentChargeOTPVerifyRequest{
+		Body: PaymentChargeOTPVerifyRequestData{
+			CardToken:   bri.cardToken,
+			ChargeToken: bri.chargeToken,
+			Passcode:    "999999", // default dev otp code
+		},
+	}
+
+	token := tokenResp.AccessToken
+	urlCreatePaymentChargeOTPVerify = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTPVerify)
+
+	resp, err := coreGateway.CreatePaymentChargeOTPVerify(token, req)
+
+	assert.Equal(bri.T(), "0000", resp.Body.Status)
+	assert.Equal(bri.T(), "SUCCESS", resp.Body.PaymentStatus)
+	assert.Equal(bri.T(), nil, err)
+}
+
+func (bri *BriSanguTestSuite) TestDirectDebit_06_DeleteCardToken() {
+	coreGateway := CoreGateway{
+		Client: bri.client,
+	}
+
+	tokenResp, _ := coreGateway.GetToken()
+	req := DeleteCardTokenRequest{
+		Body: DeleteCardTokenRequestData{
+			CardToken: bri.cardToken,
+		},
+	}
+
+	token := tokenResp.AccessToken
+	urlDeleteCardToken = fmt.Sprintf("/sandbox%s", urlDeleteCardToken)
+	resp, err := coreGateway.DeleteCardToken(token, req)
+
+	assert.Equal(bri.T(), "0000", resp.Body.Status)
+	assert.Equal(bri.T(), nil, err)
+}

--- a/request.go
+++ b/request.go
@@ -73,3 +73,13 @@ type PaymentChargeOTPVerifyRequestData struct {
 	ChargeToken string `json:"charge_token"`
 	Passcode    string `json:"passcode"`
 }
+
+// DeleteCardTokenRequest defines payload for direct debit - delete card token
+type DeleteCardTokenRequest struct {
+	Body DeleteCardTokenRequestData `json:"body"`
+}
+
+// DeleteCardTokenRequestData defines data payload for direct debit - delete card token
+type DeleteCardTokenRequestData struct {
+	CardToken string `json:"card_token"`
+}

--- a/responses.go
+++ b/responses.go
@@ -137,3 +137,14 @@ type PaymentChargeResponseData struct {
 	Location      Location               `json:"location"`
 	Metadata      map[string]interface{} `json:"metadata"`
 }
+
+// DeleteCardTokenResponse defines response for direct debit - delete card token
+type DeleteCardTokenResponse struct {
+	Body DeleteCardTokenResponseData `json:"body"`
+	ErrorResponse
+}
+
+// DeleteCardTokenResponseData defines data response for direct debit - delete card token
+type DeleteCardTokenResponseData struct {
+	Status string `json:"status"`
+}


### PR DESCRIPTION
## What does this PR do?
- This PR add idempotency key & BRI api key headers to charge direct debit payment
- Change `BRI-Signature` to `X-BRI-Signature` on direct debit request
- Differentiate base URL for direct debit, because sandbox url for direct debit is different https://apidocs.bri.co.id/#introduction

## Why are we doing this? Any context or related work?
Forgot to add these headers:
- idempotency key
- BRI api key
