### PR TITLE
add function to modify direct debit sandbox url due to different host

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,6 +55,23 @@ func getHTTPClient() *httpclient.Client {
 	)
 }
 
+// DirectDebitHostUseSandboxPrefix used to modify direct debit staging url to use /sandbox/* path due to different host
+func (c *Client) DirectDebitHostUseSandboxPrefix(use bool) {
+	if use {
+		urlCreateCardTokenOTP = "/sandbox/v1/directdebit/tokens"                   // POST
+		urlCreateCardTokenOTPVerify = "/sandbox/v1/directdebit/tokens"             // PATCH
+		urlDeleteCardToken = "/sandbox/v1/directdebit/tokens"                      // DELETE
+		urlCreatePaymentChargeOTP = "/sandbox/v1/directdebit/charges"              // POST
+		urlCreatePaymentChargeOTPVerify = "/sandbox/v1/directdebit/charges/verify" // POST
+	} else {
+		urlCreateCardTokenOTP = "/v1/directdebit/tokens"                   // POST
+		urlCreateCardTokenOTPVerify = "/v1/directdebit/tokens"             // PATCH
+		urlDeleteCardToken = "/v1/directdebit/tokens"                      // DELETE
+		urlCreatePaymentChargeOTP = "/v1/directdebit/charges"              // POST
+		urlCreatePaymentChargeOTPVerify = "/v1/directdebit/charges/verify" // POST
+	}
+}
+
 // NewRequest : send new request
 func (c *Client) NewRequest(method string, fullPath string, headers map[string]string, body io.Reader) (*http.Request, error) {
 	logLevel := c.LogLevel

--- a/core_test.go
+++ b/core_test.go
@@ -32,6 +32,7 @@ type credentials struct {
 	ClientId           string
 	ClientSecret       string
 	APIKey             string
+	IsSandbox          bool
 	CardPan            string
 	PhoneNumber        string
 	Email              string
@@ -60,6 +61,8 @@ func (bri *BriSanguTestSuite) SetupTest() {
 	bri.client.ClientId = cred.ClientId
 	bri.client.ClientSecret = cred.ClientSecret
 	bri.client.APIKey = cred.APIKey
+	bri.client.DirectDebitHostUseSandboxPrefix(cred.IsSandbox)
+
 	bri.cardPan = cred.CardPan
 	bri.phoneNumber = cred.PhoneNumber
 	bri.email = cred.Email

--- a/credential_test.toml.sample
+++ b/credential_test.toml.sample
@@ -3,6 +3,7 @@ DirectDebitBaseURL = "https://bri-direct-debit-host"  # remove /sandbox prefix, 
 ClientId = "your-client-id"
 ClientSecret = "your-client-secret"
 APIKey = "your-bri-api-key"
+IsSandbox = true
 
 # for direct debit
 CardPan = "your-card-pan"

--- a/direct_debit_test.go
+++ b/direct_debit_test.go
@@ -18,13 +18,6 @@ func generateSha1Timestamp(salt string) string {
 }
 
 func (bri *BriSanguTestSuite) TestDirectDebit_01_CreateCardToken() {
-	// modify url for unit test
-	urlCreateCardTokenOTP = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTP)
-	urlCreateCardTokenOTPVerify = fmt.Sprintf("/sandbox%s", urlCreateCardTokenOTPVerify)
-	urlCreatePaymentChargeOTP = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTP)
-	urlCreatePaymentChargeOTPVerify = fmt.Sprintf("/sandbox%s", urlCreatePaymentChargeOTPVerify)
-	urlDeleteCardToken = fmt.Sprintf("/sandbox%s", urlDeleteCardToken)
-
 	coreGateway := CoreGateway{
 		Client: bri.client,
 	}


### PR DESCRIPTION
## What does this PR do?
Because direct debit host is different we need to modify url in staging, because in staging url path starts with `/sandbox` prefix and it's needed when generate signature.

## Why are we doing this? Any context or related work?
Because direct debit host is different https://apidocs.bri.co.id/#introduction