### PR TITLE
handle response for direct debit pending transaction

### DIFF
--- a/client.go
+++ b/client.go
@@ -151,6 +151,10 @@ func (c *Client) ExecuteRequest(req *http.Request, v interface{}, vErr interface
 			if vErr != nil {
 				err = json.Unmarshal(resBody, &vErr)
 			}
+
+			if res.StatusCode == http.StatusOK {
+				return ErrPendingTransaction
+			}
 			return err
 		}
 	}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,9 @@
+package bri
+
+import (
+	"errors"
+)
+
+// ErrPendingTransaction defines error if BRI response with http status 200 but html error body.
+// Transaction should be pending and need to be inquired.
+var ErrPendingTransaction = errors.New("Transaction is pending")


### PR DESCRIPTION
## What does this PR do?
- handle response for transaction which get http status 200 but html error body from BRI. Transaction should be pending and need to be inquired later.
- Detected by http status 200 and error unmarshal

![Selection_119](https://user-images.githubusercontent.com/9508513/84013201-d1549980-a9a2-11ea-9d5c-555b3cb66d46.png)

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARS-323
